### PR TITLE
推論結果（英語表記）を日本語表記に変更する (#1)

### DIFF
--- a/frontend/app/components/Upload.tsx
+++ b/frontend/app/components/Upload.tsx
@@ -9,7 +9,7 @@ type PredictResult = {
   top3: Array<{ breed: string; score: number }>;
 };
 
-export default function Upload({ onResult }: { onResult: (r: PredictResult) => void }) {
+export default function Upload() {
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -104,7 +104,6 @@ export default function Upload({ onResult }: { onResult: (r: PredictResult) => v
     try {
       const data = process.env.NEXT_PUBLIC_API_URL ? await callApi(file) : await fakePredict(file);
       setResult(data);
-      onResult(data);
 
       if (process.env.NEXT_PUBLIC_API_URL) {
         setDescLoading(true);
@@ -165,10 +164,10 @@ export default function Upload({ onResult }: { onResult: (r: PredictResult) => v
       {result && (
         <div className="mt-8 rounded-2xl border border-dotted border-neutral-700 p-4 text-sm text-neutral-300">
           <div className="font-semibold">
-            Top-1: {result.top1.breed} ({(result.top1.score * 100).toFixed(1)}%)
+            推定結果（１位）: {result.top1.breed} ({(result.top1.score * 100).toFixed(1)}%)
           </div>
           <div className="opacity-80 mt-1">
-            Top-3:{" "}
+            上位３位:{" "}
             {result.top3
               .map((b) => `${b.breed} ${(b.score * 100).toFixed(1)}%`)
               .join(" / ")}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,16 +1,52 @@
+// "use client";
+
+// import { useState } from "react";
+// import Upload from "./components/Upload";
+
+// type PredictResult = {
+//   top1: { breed: string; score: number };
+//   top3: Array<{ breed: string; score: number }>;
+// };
+
+// export default function Page() {
+//   const [result, setResult] = useState<PredictResult | null>(null);
+
+//   return (
+//     <main className="min-h-dvh px-6 py-10 max-w-4xl mx-auto">
+//       <h1 className="text-3xl font-bold">猫種推定アプリ</h1>
+//       <p className="mt-2 opacity-80">
+//         画像をアップすると、推定された猫種と説明文を表示します。
+//       </p>
+
+//       <section className="mt-8">
+//         <Upload onResult={setResult} />
+
+//         <div className="mt-8 p-5 rounded-2xl border bg-neutral-900/30">
+//           {result ? (
+//             <div className="space-y-2">
+//               <div className="text-lg font-semibold">
+//                 Top-1: {result.top1.breed} ({(result.top1.score * 100).toFixed(1)}%)
+//               </div>
+//               <div className="text-sm opacity-80">
+//                 Top-3:{" "}
+//                 {result.top3
+//                   .map((x) => `${x.breed} ${(x.score * 100).toFixed(1)}%`)
+//                   .join(" / ")}
+//               </div>
+//             </div>
+//           ) : (
+//             <span className="opacity-70">結果はここに表示されます</span>
+//           )}
+//         </div>
+//       </section>
+//     </main>
+//   );
+// }
 "use client";
 
-import { useState } from "react";
 import Upload from "./components/Upload";
 
-type PredictResult = {
-  top1: { breed: string; score: number };
-  top3: Array<{ breed: string; score: number }>;
-};
-
 export default function Page() {
-  const [result, setResult] = useState<PredictResult | null>(null);
-
   return (
     <main className="min-h-dvh px-6 py-10 max-w-4xl mx-auto">
       <h1 className="text-3xl font-bold">猫種推定アプリ</h1>
@@ -19,25 +55,7 @@ export default function Page() {
       </p>
 
       <section className="mt-8">
-        <Upload onResult={setResult} />
-
-        <div className="mt-8 p-5 rounded-2xl border bg-neutral-900/30">
-          {result ? (
-            <div className="space-y-2">
-              <div className="text-lg font-semibold">
-                Top-1: {result.top1.breed} ({(result.top1.score * 100).toFixed(1)}%)
-              </div>
-              <div className="text-sm opacity-80">
-                Top-3:{" "}
-                {result.top3
-                  .map((x) => `${x.breed} ${(x.score * 100).toFixed(1)}%`)
-                  .join(" / ")}
-              </div>
-            </div>
-          ) : (
-            <span className="opacity-70">結果はここに表示されます</span>
-          )}
-        </div>
+        <Upload />
       </section>
     </main>
   );


### PR DESCRIPTION
概要
Issue #1 に対応し、モデルの推論結果（Top-1 / Top-3）の猫種名を日本語表記へ変換する機能を実装しました。

変更内容
・backend/data/breed_mapping_ja.json を新規追加
英語 → 日本語の猫種名マッピングを定義

・backend/api/predict.py を修正
推論結果のクラス名を API レスポンス前に日本語へ変換
CLASSES とマッピングのキー整合性を調整

・フロントエンド（Upload.tsx）の結果表示部分を日本語表記に変更
Top-1 / Top-3 の表示文言を日本語に統一
アンダースコア除去（prettify）の処理はそのまま活用
UI 上の重複表示（Page.tsx）を削除し、結果表示を Upload.tsx に一本化

目的
・推論結果と説明文（GPT生成）が混在していた英語・日本語表記を統一し、ユーザー体験を向上させるため
・アプリ内の表示をすべて日本語に揃え、ポートフォリオとしての完成度を高めるため

動作確認
以下の猫種画像で動作確認を実施し、すべて日本語表記に変換されることを確認しました：
・ラグドール
・メインクーン
・ペルシャ
・バーマン
・ベンガル
・その他全12種

また、表示箇所が重複していた UI の問題が解消されていることを確認しました。