### PR TITLE
推定された猫種に対して質問できるAIチャット機能を追加する (#2)

### DIFF
--- a/backend/api/breed_chat.py
+++ b/backend/api/breed_chat.py
@@ -1,0 +1,90 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import Literal, List
+from pathlib import Path
+import logging
+import os
+
+from openai import OpenAI
+from dotenv import load_dotenv
+
+router = APIRouter()
+
+logging.basicConfig(level=logging.INFO)
+
+# .env 読み込み
+BASE_DIR = Path(__file__).resolve().parents[1]
+ENV_PATH = BASE_DIR / ".env"
+if ENV_PATH.exists():
+    load_dotenv(ENV_PATH)
+else:
+    load_dotenv()
+
+# OpenAI クライアント
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+if OPENAI_API_KEY:
+    client = OpenAI(api_key=OPENAI_API_KEY)
+else:
+    client = None
+    logging.warning("OPENAI_API_KEY が環境変数に設定されていません。/breed_chat は動作しません。")
+
+DEFAULT_CHAT_MODEL = os.getenv("OPENAI_CHAT_MODEL", "gpt-4o-mini")
+
+
+class ChatMessage(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str
+
+
+class BreedChatRequest(BaseModel):
+    breed: str = Field(..., description="推定された猫種名（日本語表記）")
+    messages: List[ChatMessage] = Field(..., description="これまでの会話履歴（最新メッセージは user）")
+    lang: Literal["ja", "en"] = "ja"
+
+
+class BreedChatResponse(BaseModel):
+    reply: str
+
+
+@router.post("/breed_chat", response_model=BreedChatResponse)
+async def breed_chat(payload: BreedChatRequest):
+    """
+    推定された猫種について、ユーザーからの質問に回答するチャットAPI。
+    - payload.breed: 対象の猫種名（例: 'ラグドール'）
+    - payload.messages: これまでの会話履歴
+    """
+    if client is None:
+        raise HTTPException(status_code=500, detail="OPENAI_API_KEY が設定されていません。")
+    
+    if not OPENAI_API_KEY:
+        raise HTTPException(status_code=500, detail="OPENAI_API_KEY が設定されていません。")
+
+    if not payload.messages:
+        raise HTTPException(status_code=400, detail="messages は1件以上必要です。")
+
+    lang_label = "日本語" if payload.lang == "ja" else "英語"
+
+    system_content = (
+        f"あなたは猫に詳しい獣医・ブリーダーの役割を持つアシスタントです。\n"
+        f"対象の猫種は「{payload.breed}」です。\n"
+        f"- 回答は常に{lang_label}で行ってください。\n"
+        f"- {payload.breed} に関する性格、飼いやすさ、注意点、健康面などを、"
+        f"初心者にも分かりやすく、丁寧に説明してください。\n"
+        f"- 分からないことは想像で断定せず、『正確な情報がない』と伝えてください。\n"
+        f"- 医療行為の判断が必要な内容は、最終的に必ず獣医師への相談を推奨してください。"
+    )
+
+    try:
+        completion = client.chat.completions.create(
+            model=DEFAULT_CHAT_MODEL,
+            messages=[
+                {"role": "system", "content": system_content},
+                *[m.model_dump() for m in payload.messages],
+            ],
+        )
+        reply = completion.choices[0].message.content or ""
+        return BreedChatResponse(reply=reply)
+    except Exception as e:
+        logging.exception("breed_chat failed")
+        raise HTTPException(status_code=500, detail=f"Chat failed: {e}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI  # type: ignore[import]
 from fastapi.middleware.cors import CORSMiddleware  # type: ignore[import]
 from api.predict import router as predict_router
+from api.breed_chat import router as breed_chat_router
 from app.routes import describe
 
 app = FastAPI()
@@ -14,4 +15,5 @@ app.add_middleware(
 )
 
 app.include_router(predict_router)
+app.include_router(breed_chat_router)
 app.include_router(describe.router)

--- a/frontend/app/components/BreedChat.tsx
+++ b/frontend/app/components/BreedChat.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import React, { useState } from "react";
+import { fetchBreedChat, ChatMessage } from "../lib/fetchBreedChat";
+
+type Props = {
+  breed: string;
+  className?: string;
+};
+
+export default function BreedChat({ breed, className }: Props) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasBackend = !!process.env.NEXT_PUBLIC_API_URL;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || !hasBackend || loading) return;
+
+    const userMessage: ChatMessage = { role: "user", content: input.trim() };
+    const nextMessages = [...messages, userMessage];
+
+    setMessages(nextMessages);
+    setInput("");
+    setLoading(true);
+    setError(null);
+
+    try {
+      const reply = await fetchBreedChat(breed, nextMessages);
+      const assistantMessage: ChatMessage = { role: "assistant", content: reply };
+      setMessages([...nextMessages, assistantMessage]);
+    } catch (e: any) {
+      console.error(e);
+      setError(e?.message || "チャットの取得に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!hasBackend) {
+    return (
+      <div className={className}>
+        <p className="text-sm opacity-70">
+          ※ バックエンド未接続のため、AIチャット機能はローカルでは無効です。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`rounded-2xl border border-neutral-700 bg-neutral-900/40 p-4 ${className ?? ""}`}>
+      <h3 className="font-semibold mb-2">
+        「{breed}」について質問してみる
+      </h3>
+
+      <div className="max-h-64 overflow-y-auto space-y-2 mb-3 text-sm">
+        {messages.length === 0 && (
+          <p className="opacity-70">
+            例: 「性格はどんな感じ？」「一人暮らしでも飼いやすい？」「子どもとの相性は？」 など
+          </p>
+        )}
+        {messages.map((m, idx) => (
+          <div
+            key={idx}
+            className={
+              m.role === "user"
+                ? "text-right"
+                : "text-left"
+            }
+          >
+            <div
+              className={
+                "inline-block px-3 py-2 rounded-2xl " +
+                (m.role === "user"
+                  ? "bg-pink-600 text-white"
+                  : "bg-neutral-800 text-neutral-100")
+              }
+            >
+              {m.content}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input
+          type="text"
+          className="flex-1 rounded-xl bg-neutral-900 border border-neutral-700 px-3 py-2 text-sm"
+          placeholder={`${breed} について質問してみよう`}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button
+          type="submit"
+          disabled={loading || !input.trim()}
+          className="px-4 py-2 rounded-xl bg-pink-600 hover:bg-pink-500 disabled:opacity-50 text-sm"
+        >
+          {loading ? "回答中..." : "送信"}
+        </button>
+      </form>
+
+      {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/app/components/Upload.tsx
+++ b/frontend/app/components/Upload.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { fetchDescription } from "../lib/fetchDescription";
 import BreedDescriptionCard from "./BreedDescriptionCard";
 import { BreedDescription } from "../types/description";
+import BreedChat from "./BreedChat";
 
 type PredictResult = {
   top1: { breed: string; score: number };
@@ -178,6 +179,11 @@ export default function Upload() {
       {/* 説明カードは 結果の下 に出す */}
       {descLoading && <p className="mt-6 opacity-80">説明文を生成中…</p>}
       {desc && <BreedDescriptionCard className="mt-6" data={desc} />}
+
+      {/* 猫種ごとのAIチャット */}
+      {result && (
+        <BreedChat className="mt-6" breed={result.top1.breed} />
+      )}
 
       {error && <p className="mt-4 text-red-400">{error}</p>}
     </div>

--- a/frontend/app/lib/fetchBreedChat.ts
+++ b/frontend/app/lib/fetchBreedChat.ts
@@ -1,0 +1,28 @@
+export type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+export async function fetchBreedChat(breed: string, messages: ChatMessage[]) {
+  const base = process.env.NEXT_PUBLIC_API_URL;
+  if (!base) {
+    throw new Error("NEXT_PUBLIC_API_URL is not set");
+  }
+
+  const res = await fetch(`${base}/breed_chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      breed,
+      messages,
+      lang: "ja",
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Chat API error: ${res.status} ${await res.text().catch(() => "")}`);
+  }
+
+  const json = await res.json();
+  return json.reply as string;
+}


### PR DESCRIPTION
## 概要
Issue #2 に対応し、推定された猫種に対して自由に質問できる
AIチャット機能を追加しました。

## 追加内容
### **backend**
- `breed_chat.py` を新規追加
  - OpenAI Chat API を利用し、猫種ごとの質問に回答する機能を実装
  - `.env` の読み込みを明示的に行うように修正
- `app/main.py` に `breed_chat` ルーターを追加

### **frontend**
- `fetchBreedChat.ts` を新規追加
  - `/breed_chat` エンドポイントと通信するクライアント関数
- `BreedChat.tsx` を新規作成
  - チャットUI（バブル表示、質問入力、送信ボタン）を実装
- `Upload.tsx` を修正
  - 推論結果と説明カードの下にチャット欄を追加

## 目的
- 猫種説明を読むだけでなく、
  ユーザーが自由に質問できる「対話型アプリ」へ拡張するため
- ChatGPT API を使った実践的な機能として、ポートフォリオの価値を高める

## 動作確認
- 推論 → 説明文 → AIチャット の一連の流れを全猫種で動作確認
- OpenAI APIキーありの場合のみ正常動作
- キー未設定時は 500 エラーを返し、クラッシュしないことを確認
- 日本語の質問に対し、自然な日本語回答が返ることを確認

## 補足
- Chat機能はページリロードで履歴クリアされる仕様
- ストリーミング対応は必要であれば後日追加可能
